### PR TITLE
setActiveViewPortNode => setActiveViewportNode

### DIFF
--- a/src/slick-frozen.grid.js
+++ b/src/slick-frozen.grid.js
@@ -559,7 +559,7 @@ function SlickGrid(container, data, columns, options){
   }
 
   function getActiveViewportNode(element){
-    setActiveViewPortNode(element);
+    setActiveViewportNode(element);
 
     return $activeViewportNode[0];
   }


### PR DESCRIPTION
This fixes https://github.com/DimitarChristoff/slickgrid-es6/issues/32